### PR TITLE
Add support for symbol lookup.

### DIFF
--- a/whisp-parser/src/lib.rs
+++ b/whisp-parser/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod tree;
 pub mod ops;
 pub mod parser;
+pub mod symbol;

--- a/whisp-parser/src/parser/control_flow.rs
+++ b/whisp-parser/src/parser/control_flow.rs
@@ -1,9 +1,11 @@
 use crate::parser::ll_parser::{ Parser, LLParser };
+use crate::symbol::{ SymbolTable, SymbolInfo };
 use crate::tree::ASTNode;
+
 
 use whisp_lexer::token::Token;
 
-impl LLParser {
+impl<'a> LLParser<'a> {
     /// ControlFlow ::= IfStatement | WhileStatement | ForStatement | Return
     pub fn parse_control_flow(&mut self) -> Result<ASTNode, String> {
         match self.peek() {
@@ -83,6 +85,7 @@ mod test_control_flow {
 
     #[test]
     fn test_parse_if_statement() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
             Token::If,
             Token::LParen,
@@ -99,7 +102,9 @@ mod test_control_flow {
             Token::Int(4),
             Token::Semicolon,
             Token::RBrace,
-        ]);
+        ],
+        &mut symbols
+    );
 
         let result = parser.parse_control_flow();
         assert!(result.is_ok());
@@ -121,17 +126,20 @@ mod test_control_flow {
 
     #[test]
     fn test_parse_if_statement_fail_when_non_bool_expr() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::If,
-            Token::Int(1),
-            Token::Add,
-            Token::Int(2),
-            Token::LBrace,
-            Token::Return,
-            Token::Int(7),
-            Token::Semicolon,
-            Token::RBrace
-        ]);
+                Token::If,
+                Token::Int(1),
+                Token::Add,
+                Token::Int(2),
+                Token::LBrace,
+                Token::Return,
+                Token::Int(7),
+                Token::Semicolon,
+                Token::RBrace
+            ],
+            &mut symbols
+        );
 
         let result = parser.parse_control_flow();
 
@@ -141,11 +149,14 @@ mod test_control_flow {
 
     #[test]
     fn test_parse_return_statement() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::Return,
-            Token::Int(42),
-            Token::Semicolon,
-        ]);
+                Token::Return,
+                Token::Int(42),
+                Token::Semicolon,
+            ],
+            &mut symbols
+        );
 
         let result = parser.parse_control_flow();
 
@@ -158,15 +169,18 @@ mod test_control_flow {
 
     #[test]
     fn test_parse_while_statement() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::While,
-            Token::Bool(false),
-            Token::LBrace,
-            Token::Return,
-            Token::Int(0),
-            Token::Semicolon,
-            Token::RBrace,
-        ]);
+                Token::While,
+                Token::Bool(false),
+                Token::LBrace,
+                Token::Return,
+                Token::Int(0),
+                Token::Semicolon,
+                Token::RBrace,
+            ],
+            &mut symbols
+        );
 
         let result = parser.parse_control_flow();
         assert!(result.is_ok());
@@ -184,22 +198,25 @@ mod test_control_flow {
 
     #[test]
     fn test_parse_for_statement() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::For,
-            Token::Identifier("i".into()),
-            Token::In,
-            Token::Array,
-            Token::LBracket,
-            Token::Int(7),
-            Token::Comma,
-            Token::Int(3),
-            Token::RBracket,
-            Token::LBrace,
-            Token::Return,
-            Token::Identifier("i".into()),
-            Token::Semicolon,
-            Token::RBrace,
-        ]);
+                Token::For,
+                Token::Identifier("i".into()),
+                Token::In,
+                Token::Array,
+                Token::LBracket,
+                Token::Int(7),
+                Token::Comma,
+                Token::Int(3),
+                Token::RBracket,
+                Token::LBrace,
+                Token::Return,
+                Token::Identifier("i".into()),
+                Token::Semicolon,
+                Token::RBrace,
+            ],
+            &mut symbols
+        );
 
         let result = parser.parse_control_flow();
         assert!(result.is_ok());

--- a/whisp-parser/src/parser/expressions.rs
+++ b/whisp-parser/src/parser/expressions.rs
@@ -1,10 +1,11 @@
 use crate::parser::ll_parser::{ Parser, LLParser };
+use crate::symbol::{ SymbolTable, SymbolInfo };
 use crate::tree::ASTNode;
 use crate::ops::Operation;
 
 use whisp_lexer::token::Token;
 
-impl LLParser {
+impl<'a> LLParser<'a> {
     /// Expr ::= AssignmentExpr
     pub fn parse_expression(&mut self) -> Result<ASTNode, String> {
         self.parse_assignment_expr()
@@ -16,6 +17,13 @@ impl LLParser {
            matches!(self.lookahead(), Token::Assign) 
         {
             let identifier = self.parse_identifier()?;
+
+            if let ASTNode::Identifier { ref name } = identifier {
+                if self.symbols.resolve(name).is_none() {
+                    return Err(format!("Undeclared variable '{}'.", name));
+                }
+            }
+
             self.advance();
             let body = self.parse_expression()?;
             return Ok(ASTNode::assign(identifier, body));
@@ -383,14 +391,21 @@ mod test_expressions {
 
     #[test]
     fn test_parse_assignment_expr() {
-        let mut parser = LLParser::new(vec![
-            Token::Identifier("x".into()),
-            Token::Assign,
-            Token::Int(42),
-            Token::Semicolon,
-        ]);
+        let mut symbols = SymbolTable::new();
 
-        let result = parser.parse_expression();
+        // Mock declartion of 'x' variable.
+        symbols.define("x".to_string(), SymbolInfo);
+
+        let mut parser = LLParser::new(vec![
+                Token::Identifier("x".into()),
+                Token::Assign,
+                Token::Int(42),
+                Token::Semicolon,
+            ],
+            &mut symbols
+        );
+
+        let result = parser.parse_assignment_expr();
 
         match result {
             Ok(ast) => {
@@ -405,14 +420,17 @@ mod test_expressions {
 
     #[test]
     fn test_parse_arithmetic_expr() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::Int(5),
-            Token::Add,
-            Token::Int(3),
-            Token::Mul,
-            Token::Int(2),
-            Token::Semicolon,
-        ]);
+                Token::Int(5),
+                Token::Add,
+                Token::Int(3),
+                Token::Mul,
+                Token::Int(2),
+                Token::Semicolon,
+            ],
+            &mut symbols
+        );
         let result = parser.parse_expression();
 
         match result {
@@ -433,7 +451,12 @@ mod test_expressions {
 
     #[test]
     fn test_parse_identifier() {
-        let mut parser = LLParser::new(vec![Token::Identifier("y".into())]);
+        let mut symbols = SymbolTable::new();
+        let mut parser = LLParser::new(vec![
+                Token::Identifier("y".into())
+            ], 
+            &mut symbols
+        );
         let ast = parser.parse_identifier().unwrap();
 
         assert_eq!(ast, ASTNode::identifier("y"));
@@ -441,17 +464,20 @@ mod test_expressions {
 
     #[test]
     fn test_parse_literal() {
+        let mut symbols = SymbolTable::new();
         let mut parser = LLParser::new(vec![
-            Token::Int(10),
-            Token::String("hello".into()),
-            Token::Bool(true),
-            Token::Array,
-            Token::LBracket,
-            Token::Int(1),
-            Token::Comma,
-            Token::Int(2),
-            Token::RBracket
-        ]);
+                Token::Int(10),
+                Token::String("hello".into()),
+                Token::Bool(true),
+                Token::Array,
+                Token::LBracket,
+                Token::Int(1),
+                Token::Comma,
+                Token::Int(2),
+                Token::RBracket
+            ],
+            &mut symbols
+        );
 
         let int_ast = parser.parse_literal().unwrap();
         assert_eq!(int_ast, ASTNode::numeric(10));

--- a/whisp-parser/src/parser/functions.rs
+++ b/whisp-parser/src/parser/functions.rs
@@ -1,14 +1,20 @@
 use crate::parser::ll_parser::{ Parser, LLParser };
+use crate::symbol::{ SymbolTable, SymbolInfo };
 use crate::tree::ASTNode;
 use crate::ops::Operation;
 
 use whisp_lexer::token::Token;
 
-impl LLParser {
+impl<'a> LLParser<'a> {
     /// Function ::= 'def' Identifier '(' Params ')' Block
     pub fn parse_function_def(&mut self) -> Result<ASTNode, String> {
         self.expect(Token::Def);
+
         let identifier = self.parse_identifier()?;
+        let ASTNode::Identifier { ref name } = identifier 
+        else {
+            return Err("Expected function name identifier after 'def'".to_string());
+        };
 
         self.expect(Token::LParen);
         let params = self.parse_params()?;
@@ -16,14 +22,24 @@ impl LLParser {
 
         let body = self.parse_block()?;
 
+        self.symbols.define(name.clone(), SymbolInfo);
+
         Ok(ASTNode::function_def(identifier, params, body))
     }
 
     /// Call ::= Identifier '(' Args ')'
     pub fn parse_call_function(&mut self) -> Result<ASTNode, String> {
         let identifier = self.parse_identifier()?;
-        self.expect(Token::LParen);
+        let ASTNode::Identifier { ref name } = identifier 
+        else {
+            return Err("Expected function identifier".to_string());
+        };
 
+        if self.symbols.resolve(name).is_none() {
+            return Err(format!("Undefined function name found '{}'", name));
+        }
+
+        self.expect(Token::LParen);
         let args = self.parse_args()?;
         self.expect(Token::RParen);
 
@@ -76,7 +92,20 @@ impl LLParser {
             Token::String(_)
             | Token::Int(_)
             | Token::Bool(_) => self.parse_literal(),
-            Token::Identifier(_) => self.parse_identifier(),
+            Token::Identifier(_) => {
+                let identifier = self.parse_identifier();
+
+                let Ok(ASTNode::Identifier { ref name }) = identifier 
+                else {
+                    return Err(format!("Expected identifier as argument, got {:?}", identifier));
+                };
+
+                if self.symbols.resolve(name).is_none() {
+                    return Err(format!("Undeclared variable '{}'", name));
+                }
+
+                identifier
+            },
             _ => Err(format!("Expected argument term, found {:?}", self.peek())),
         }
     }
@@ -105,6 +134,7 @@ mod test_functions {
 
     #[test]
     fn test_function_def() {
+        let mut symbols = SymbolTable::new();
         let tokens = vec![
             Token::Def,
             Token::Identifier("my_function".into()),
@@ -121,11 +151,12 @@ mod test_functions {
             Token::Add,
             Token::Identifier("b".into()),
             Token::Semicolon,
-            Token::RBrace
+            Token::RBrace,
+            Token::Eof
         ];
 
-        let mut parser = LLParser::new(tokens);
-        let ast = parser.parse_statements();
+        let mut parser = LLParser::new(tokens, &mut symbols);
+        let ast = parser.parse();
 
         assert!(ast.is_ok());
 
@@ -153,25 +184,100 @@ mod test_functions {
 
     #[test]
     fn test_call_function() {
+        let mut symbols = SymbolTable::new();
         let tokens = vec![
+            Token::Def,
             Token::Identifier("my_function".into()),
             Token::LParen,
+            Token::Identifier("a".into()),
+            Token::Comma,
+            Token::Identifier("b".into()),
+            Token::RParen,
+            Token::LBrace,
+            Token::Let,
+            Token::Identifier("result".into()),
+            Token::Assign,
+            Token::Identifier("a".into()),
+            Token::Add,
+            Token::Identifier("b".into()),
+            Token::Semicolon,
+            Token::RBrace,
+            Token::Let,
+            Token::Identifier("a".into()),
+            Token::Assign,
             Token::Int(5),
+            Token::Semicolon,
+            Token::Identifier("my_function".into()),
+            Token::LParen,
+            Token::Identifier("a".into()),
             Token::Comma,
             Token::Int(10),
             Token::RParen,
+            Token::Semicolon,
+            Token::Eof
         ];
-        let mut parser = LLParser::new(tokens);
-        let ast = parser.parse_call_function();
+        let mut parser = LLParser::new(tokens, &mut symbols);
+        let ast = parser.parse();
 
         assert!(ast.is_ok());
-        match ast.unwrap() {
-            ASTNode::Call { name, args } => {
-                assert_eq!(name, Box::new(ASTNode::identifier("my_function")));
-                assert_eq!(args.len(), 2);
-                assert_eq!(args[0], ASTNode::numeric(5));
-            },
-            _ => panic!("Expected a function call"),
-        }
+        let expected_ast = ASTNode::statements(vec![
+            ASTNode::function_def(
+                ASTNode::identifier("my_function"),
+                vec![
+                    ASTNode::identifier("a"),
+                    ASTNode::identifier("b"),
+                ],
+                ASTNode::statements(vec![
+                    ASTNode::let_binding(
+                        ASTNode::identifier("result"),
+                        ASTNode::binary_op(
+                            Operation::Add,
+                            ASTNode::identifier("a"),
+                            ASTNode::identifier("b"),
+                        ),
+                    ),
+                ]),
+            ),
+            ASTNode::let_binding(
+                ASTNode::identifier("a"),
+                ASTNode::numeric(5),
+            ),
+            ASTNode::call(
+                ASTNode::identifier("my_function"),
+                vec![
+                    ASTNode::identifier("a"),
+                    ASTNode::numeric(10),
+                ],
+            ),
+        ]);
+
+        assert_eq!(ast.unwrap(), expected_ast);
+    }
+
+    #[test]
+    fn test_call_undefined_function_then_fail() {
+        let mut symbols = SymbolTable::new();
+        let tokens = vec![
+            Token::Let,
+            Token::Identifier("a".into()),
+            Token::Assign,
+            Token::Int(5),
+            Token::Semicolon,
+            Token::Identifier("my_function".into()),
+            Token::LParen,
+            Token::Identifier("a".into()),
+            Token::Comma,
+            Token::Int(10),
+            Token::RParen,
+            Token::Semicolon,
+            Token::Eof
+        ];
+        let mut parser = LLParser::new(tokens, &mut symbols);
+        let ast = parser.parse();
+
+        assert!(ast.is_err());
+        
+        let err = ast.unwrap_err();
+        assert!(err.contains("Undefined function name found 'my_function'"));
     }
 }

--- a/whisp-parser/src/parser/ll_parser.rs
+++ b/whisp-parser/src/parser/ll_parser.rs
@@ -1,5 +1,6 @@
 use whisp_lexer::token::Token;
 use crate::tree::ASTNode;
+use crate::symbol::SymbolTable;
 
 pub trait Parser {
     fn peek(&self) -> &Token;
@@ -9,21 +10,24 @@ pub trait Parser {
     fn parse(&mut self) -> Result<ASTNode, String>;
 }
 
-pub struct LLParser {
+pub struct LLParser<'a> {
     stream: Vec<Token>,
-    cursor: usize
+    cursor: usize,
+
+    pub symbols: &'a mut SymbolTable
 }
 
-impl LLParser {
-    pub fn new(stream: Vec<Token>) -> Self {
+impl<'a> LLParser<'a> {
+    pub fn new(stream: Vec<Token>, symbols: &'a mut SymbolTable) -> Self {
         LLParser {
             stream,
             cursor: 0,
+            symbols: symbols
         }
     }
 }
 
-impl Parser for LLParser {
+impl<'a> Parser for LLParser<'a> {
     fn peek(&self) -> &Token {
         self.stream
             .get(self.cursor)

--- a/whisp-parser/src/parser/statements.rs
+++ b/whisp-parser/src/parser/statements.rs
@@ -1,9 +1,10 @@
 use crate::parser::ll_parser::{ Parser, LLParser };
+use crate::symbol::{ SymbolTable, SymbolInfo };
 use crate::tree::ASTNode;
 
 use whisp_lexer::token::Token;
 
-impl LLParser {
+impl<'a> LLParser<'a> {
     /// Stmts ::= Stmt Stmts | ε
     pub fn parse_statements(&mut self) -> Result<ASTNode, String> {
         let mut stmts = Vec::<ASTNode>::new();
@@ -20,7 +21,7 @@ impl LLParser {
 
     /// Stmt ::= Expr ';' | LetBinding | FunctionDef | Block | ControlFlow
     pub fn parse_statement(&mut self) -> Result<ASTNode, String> {
-        let result = match self.peek() {
+        match self.peek() {
             Token::If
             | Token::While 
             | Token::For 
@@ -30,31 +31,46 @@ impl LLParser {
             Token::LBrace   => self.parse_block(),
             _ => { 
                 let expr = self.parse_expression()?;
+
+                if let ASTNode::Identifier { ref name } = expr {
+                    if self.symbols.resolve(name).is_none() {
+                        return Err(format!("Undeclared variable '{}'.", name));
+                    }
+                }
                 self.expect(Token::Semicolon);
+
                 Ok(expr)
             }
-        };
-
-        result
+        }
     }
 
     /// LetBinding ::= 'let' Identifier '=' Expr ';'
     pub fn parse_letbinding(&mut self) -> Result<ASTNode, String> {
         self.expect(Token::Let);
-        let identifier = self.parse_identifier()?;
 
+        let identifier = self.parse_identifier()?;
+        let ASTNode::Identifier { name } = &identifier else {
+            return Err("Expected identifier after 'let'".to_string());
+        };
         self.expect(Token::Assign);
+
         let body = self.parse_expression()?;
+
         self.expect(Token::Semicolon);
+        self.symbols.define(name.clone(), SymbolInfo);
 
         Ok(ASTNode::let_binding(identifier, body))
     }
 
     /// Block ::= '{' Stmts '}'
     pub fn parse_block(&mut self) -> Result<ASTNode, String> {
+        self.symbols.enter_scope();
         self.expect(Token::LBrace);
+
         let stmts = self.parse_statements()?;
+
         self.expect(Token::RBrace);
+        self.symbols.exit_scope();
 
         Ok(stmts)
     }
@@ -68,6 +84,7 @@ mod test_statements {
 
     #[test]
     fn test_parse_letbinding_statements() {
+        let mut symbols = SymbolTable::new();
         let tokens = vec![
             Token::Let,
             Token::Identifier("x".into()),
@@ -81,7 +98,7 @@ mod test_statements {
             Token::Semicolon
         ];
 
-        let mut parser = LLParser::new(tokens);
+        let mut parser = LLParser::new(tokens, &mut symbols);
         let ast = parser.parse_statements();
 
         assert!(ast.is_ok());
@@ -104,6 +121,7 @@ mod test_statements {
 
     #[test]
     fn test_block_statements() {
+        let mut symbols = SymbolTable::new();
         let tokens = vec![
             Token::LBrace,
             Token::Let,
@@ -114,7 +132,7 @@ mod test_statements {
             Token::RBrace
         ];
 
-        let mut parser = LLParser::new(tokens);
+        let mut parser = LLParser::new(tokens, &mut symbols);
         let ast = parser.parse_statements();
 
         assert!(ast.is_ok());

--- a/whisp-parser/src/symbol.rs
+++ b/whisp-parser/src/symbol.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct SymbolInfo;
+
+#[derive(Debug)]
+pub struct SymbolTable {
+    stack: Vec<HashMap<String, SymbolInfo>>
+}
+
+impl SymbolTable {
+    pub fn new() -> Self {
+        SymbolTable {
+            stack: vec![HashMap::new()],
+        }
+    }
+
+    pub fn enter_scope(&mut self) {
+        self.stack.push(HashMap::new());
+    }
+
+    pub fn exit_scope(&mut self) {
+        self.stack.pop();
+    }
+
+    pub fn define(&mut self, name: String, info: SymbolInfo) {
+        if let Some(current) = self.stack.last_mut() {
+            current.insert(name.clone(), info);
+        }
+    }
+
+    pub fn resolve(&self, name: &str) -> Option<&SymbolInfo> {
+        for scope in self.stack.iter().rev() {
+            if let Some(info) = scope.get(name) {
+                return Some(info);
+            }
+        }
+        None
+    }
+}

--- a/whisp-runtime/src/runtime/builtin.rs
+++ b/whisp-runtime/src/runtime/builtin.rs
@@ -118,7 +118,7 @@ mod test_builtin_functions {
     use crate::environment::Environment;
 
     #[test]
-    fn test_print() {
+    fn test_max() {
         let mut env = Environment::new();
 
         register_builtin(Rc::new(MaxFn), &mut env);


### PR DESCRIPTION
Some times variables and functions are referenced without being declared or defined in a scope. When this happens, the parser should catch these bad behaviours before constructing the AST.

Defence in depth -- ofcourse the evaluator or the compiler will also protect itself from such behaviour.