### PR TITLE
fix: Bug fix comparision expression in the parser.

### DIFF
--- a/whisp-parser/src/parser/expressions.rs
+++ b/whisp-parser/src/parser/expressions.rs
@@ -81,8 +81,7 @@ where
         self.parse_comp_expr_tail(lhs)
     }
 
-    /// CompExprTail ::= ('==' | '<' | '>' | '<=' | '>=') AddSubExpr CompExprTail 
-    ///                | ε
+    /// CompExprTail ::= ('==' | '<' | '>' | '<=' | '>=') AddSubExpr CompExprTail | ε
     pub fn parse_comp_expr_tail(
         &mut self, 
         mut lhs: ASTNode
@@ -98,8 +97,8 @@ where
                 Token::Equal => Operation::Eq,
                 Token::GreaterEqual => Operation::Ge,
                 Token::GreaterThan  => Operation::Gt,
-                Token::LessThan     => Operation::Le,
-                Token::LessEqual    => Operation::Lt,
+                Token::LessThan     => Operation::Lt,
+                Token::LessEqual    => Operation::Le,
                 _ => unreachable!(),
             };
 
@@ -267,8 +266,8 @@ where
             Token::Equal        => Operation::Eq,
             Token::GreaterEqual => Operation::Ge,
             Token::GreaterThan  => Operation::Gt,
-            Token::LessThan     => Operation::Le,
-            Token::LessEqual    => Operation::Lt,
+            Token::LessThan     => Operation::Lt,
+            Token::LessEqual    => Operation::Le,
             _ => return Err(format!("Expected comparison operator, found {:?}", self.peek())),
         };
         self.advance();

--- a/whisp-runtime/src/runtime/interpreter.rs
+++ b/whisp-runtime/src/runtime/interpreter.rs
@@ -150,7 +150,6 @@ impl Evaluator for Interpreter {
             Operation::And => lhs_val.and(rhs_val),
             Operation::Or  => lhs_val.or(rhs_val),
         };
-
         Ok(result)
     }
 
@@ -246,6 +245,7 @@ impl Evaluator for Interpreter {
         while matches!(eval(self, cond)?, Value::Bool(true)) {
             eval(self, body)?;
         }
+
         self.exit_scope();
     
         Ok(Value::Void(()))


### PR DESCRIPTION
The following epxression would always return false:

`3 <= 3`

instead of returning true.